### PR TITLE
lock down pyScss==1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ kombu>=2.5.0,<=3.0.7
 # for SECURE_KEY generation
 lockfile>=0.8,<=0.8
 netaddr>=0.7.12,<=0.7.13
-pyScss>=1.2.1,<1.3  # MIT License
+pyScss==1.2.1  # MIT License
 python-ceilometerclient>=1.0.6,<1.0.13
 python-cinderclient>=1.1.0,<=1.1.1
 python-glanceclient>=0.14.0,<=0.15.0


### PR DESCRIPTION
it was installing pyScss==1.3.0.a1 which caused failures in horizon commands.
