### PR TITLE
Add more strict python requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,13 @@
 # be installed in a specific order.
 #
 # PBR should always appear first
-pbr<2.0,>=1.4
+pbr==0.11.0
+
+oslo.config==1.6.0
+oslo.utils==1.4.0
+oslo.i18n==1.3.1
+stevedore==1.3.0
+cliff==1.13.0
 # Horizon Core Requirements
 Django>=1.4.2,<1.7
 django_compressor>=1.4,<=1.4
@@ -22,12 +28,12 @@ kombu>=2.5.0,<=3.0.7
 lockfile>=0.8,<=0.8
 netaddr>=0.7.12,<=0.7.13
 pyScss>=1.2.1,<1.3  # MIT License
-python-ceilometerclient>=1.0.6,<1.0.13
+python-ceilometerclient>=1.0.6,<1.0.12
 python-cinderclient>=1.1.0,<=1.1.1
 python-glanceclient>=0.14.0,<=0.15.0
 python-heatclient>=0.2.9,<0.3.0
 python-keystoneclient>=0.10.0,<1.2.0
-python-neutronclient>=2.3.6,<2.4.0
+python-neutronclient>=2.3.6,<2.3.12
 python-novaclient>=2.18.0,<=2.20.0
 python-saharaclient>=0.7.3,<=0.7.6
 python-swiftclient>=2.2.0,<=2.3.1


### PR DESCRIPTION
python-neutronclient 2.3.12 brings new requirements into the mix that
conflict, so add a restriction on that verison. Also force our PBR
version to avoid a cascade of fun.
