### PR TITLE
Story 97561: Task 104645 hide/add UI panels depending on the user role

### DIFF
--- a/openstack_dashboard/api/keystone.py
+++ b/openstack_dashboard/api/keystone.py
@@ -144,9 +144,14 @@ def keystoneclient(request, admin=False):
     """
     user = request.user
     if admin:
-        if not policy.check((("identity", "admin_required"),), request):
-            raise exceptions.NotAuthorized
-        endpoint_type = 'adminURL'
+        if policy.check((('get_pseudo_admin_endpoints'),), request):
+            endpoint_type = getattr(settings,
+                                'OPENSTACK_ENDPOINT_TYPE',
+                                'internalURL')
+       else:
+            if not policy.check((("identity", "admin_required"),), request):
+                raise exceptions.NotAuthorized
+            endpoint_type = 'adminURL'
     else:
         endpoint_type = getattr(settings,
                                 'OPENSTACK_ENDPOINT_TYPE',


### PR DESCRIPTION
Story 97561: Task 104645 - added a check for a rule in keystone_policy.json to get the allowed endpoints for any pseudo admin roles a user can define in keystone_policy.json.  
