### PR TITLE
Pin django_compressor to less than 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pbr!=0.7,<1.0,>=0.6
 Babel>=1.3
 Django<1.8,>=1.4.2
 Pint>=0.5 # BSD
-django-compressor>=1.4
+django-compressor>=1.4,<2.0
 django-openstack-auth<1.3.0,>=1.2.0
 django-pyscss<2.0.0,>=1.0.3 # BSD License (2 clause)
 eventlet!=0.17.0,>=0.16.1


### PR DESCRIPTION
The release of django_compressor 2.0 drops support for Django older than
1.8. In Kilo, Horizon requires a Django version older than 1.8. Thus we
cannot use django_compressor 2.0.

Tracked upstream at https://review.openstack.org/#/c/265025/

Change-Id: Ie9cf7508ac390cba72bebd6afb41b024ba05e373
