### PR TITLE
pin django-os-auth version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Babel>=1.3
 Django<1.8,>=1.4.2
 Pint>=0.5 # BSD
 django-compressor>=1.4,<2.0
-django-openstack-auth<1.3.0,>=1.2.0
+django-openstack-auth<1.3.0,>=1.2.0,!=1.2.2
 django-pyscss<2.0.0,>=1.0.3 # BSD License (2 clause)
 eventlet!=0.17.0,>=0.16.1
 httplib2>=0.7.5


### PR DESCRIPTION
django-openstack-auth 1.2.2 causes problems with our horizon. 
